### PR TITLE
[fix] rmDevice戻り値

### DIFF
--- a/SPICREATE 2.0.0/src/SPICREATE.cpp
+++ b/SPICREATE 2.0.0/src/SPICREATE.cpp
@@ -92,6 +92,7 @@ bool SPICreate::rmDevice(int deviceHandle)
         // printf("[ERROR] SPI bus remove device failed : %d\n", e);
         return false;
     }
+    return true;
 }
 void SPICreate::sendCmd(uint8_t cmd, int deviceHandle)
 {


### PR DESCRIPTION
## 変更概要

SPICREATEのrmDeviceで
lib/SPICREATE 2.0.0/src/SPICREATE.cpp: In member function 'bool arduino::esp32::spi::dma::SPICreate::rmDevice(int)':
lib/SPICREATE 2.0.0/src/SPICREATE.cpp:95:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
 の警告への対応

## 変更点の詳細

該当関数に戻り値を追加
