### PR TITLE
fix(SPI_CREATE): overflow dev handle array

### DIFF
--- a/SPICREATE 2.0.0/src/SPICREATE.h
+++ b/SPICREATE 2.0.0/src/SPICREATE.h
@@ -29,7 +29,7 @@ namespace arduino
                 class SPICreate
                 {
                     spi_bus_config_t bus_cfg = {};
-                    spi_device_handle_t handle[3];
+                    spi_device_handle_t handle[4];
                     int deviceNum{0};
 #if IS_S3
                     spi_host_device_t host{SPI2_HOST};


### PR DESCRIPTION
## 変更概要

SPI_CREATEにおいて、3つ以上のSPIを登録しようとするとエラーにならずに配列のオーバーフローが発生するバグの修整

## 後方互換性

- [x] 既存コードとの後方互換性を保っている

## 動作確認

- [x] 実際にセンサを接続して動作確認を行った

## 種別

- [ ] 新規センサのライブラリ

- [x] 既存センサのライブラリ
    - [ ] 新機能の追加
    - [x] バグ修正
    - [ ] その他

## 変更点の詳細